### PR TITLE
qbee-agent.service.in: Adjust order

### DIFF
--- a/meta-qbee/recipes-qbee/qbee-agent/files/qbee-agent.service.in
+++ b/meta-qbee/recipes-qbee/qbee-agent/files/qbee-agent.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=The Qbee fleet management agent
-After=network.target
+Wants=network-online.target
+After=systemd-resolved.service network-online.target
 
 [Service]
 RootDirectory=/


### PR DESCRIPTION
Start qbee-agent.service.in after systemd-resolved.service and network-online.target to avoid the following warnings and errors:

```
[WARNING] failed to get config from API: failed to send API request: Get "https://device.app.qbee.io:443/v1/org/device/auth/config": dial tcp: lookup device.app.qbee.io on 1.0.0.1:53: dial udp 1.0.0.1:53: connect: network is unreachable
```

```
[ERROR] failed to do check-in: failed to send API request: Get "https://device.app.qbee.io:443/v1/org/device/auth/agent/arm64/checkin": dial tcp: lookup device.app.qbee.io on 1.0.0.1:53: dial udp 1.0.0.1:53: connect: network is unreachable
```
