### PR TITLE
DEV-2576: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: meta-qbee-pr-tests
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/qbee-io/meta-qbee/security/code-scanning/1](https://github.com/qbee-io/meta-qbee/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and builds it, it only needs read access to repository contents. The best way to fix this is to add `permissions: { contents: read }` at the top level of the workflow file, just below the `name:` line and before the `on:` block. This will apply the permission restriction to all jobs in the workflow. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
