### PR TITLE
DEV-2734: Remove comment + custom timeout

### DIFF
--- a/meta-qbee/recipes-qbee/qbee-agent/files/qbee-agent.service.in
+++ b/meta-qbee/recipes-qbee/qbee-agent/files/qbee-agent.service.in
@@ -11,7 +11,7 @@ ExecStartPre=/etc/qbee/yocto/qbee-bootstrap-prep.sh
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
-#EnvironmentFile=-/etc/default/qbee-agent
+TimeoutStopSec=3600
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.
 StartLimitInterval=10

--- a/meta-qbee/recipes-qbee/qbee-agent/qbee-agent.inc
+++ b/meta-qbee/recipes-qbee/qbee-agent/qbee-agent.inc
@@ -112,9 +112,9 @@ EOF
 
 # Re-generate system certificates to include qbee CA so that third party systems
 # can communicate with the device backend
-pkg_postinst_ontarget:${PN} () {
+pkg_postinst:${PN} () {
 #!/bin/sh -e
 
-SYSROOT=$D $D$sbindir/update-ca-certificates
+$D$sbindir/update-ca-certificates --sysroot $D
 }
 

--- a/meta-qbee/recipes-qbee/qbee-agent/qbee-agent.inc
+++ b/meta-qbee/recipes-qbee/qbee-agent/qbee-agent.inc
@@ -112,7 +112,7 @@ EOF
 
 # Re-generate system certificates to include qbee CA so that third party systems
 # can communicate with the device backend
-pkg_postinst:${PN} () {
+pkg_postinst_ontarget:${PN} () {
 #!/bin/sh -e
 
 SYSROOT=$D $D$sbindir/update-ca-certificates


### PR DESCRIPTION
This pull request introduces a couple of targeted improvements to the `qbee-agent` service configuration and its installation script. The main changes focus on service stop behavior and the certificate update process.

Service configuration improvements:

* Increased the `TimeoutStopSec` for the `qbee-agent` systemd service to 3600 seconds, allowing the service more time to shut down gracefully before being forcefully terminated.

Installation script adjustment:

* Updated the post-install script to use the `--sysroot` flag with `update-ca-certificates`, ensuring certificates are updated in the correct root filesystem during installation.This pull request makes a minor adjustment to the `qbee-agent.service.in` systemd service file by increasing the stop timeout duration for the service.