### PR TITLE
DEV-2750: Remove unhandled reload

### DIFF
--- a/meta-qbee/recipes-qbee/qbee-agent/files/qbee-agent.service.in
+++ b/meta-qbee/recipes-qbee/qbee-agent/files/qbee-agent.service.in
@@ -8,7 +8,6 @@ EnvironmentFile=-/etc/default/qbee-agent
 RootDirectory=/
 ExecStart=/usr/bin/qbee-agent -c @QBEE_CONF_DIR@ -s @QBEE_STATE_DIR@ start
 ExecStartPre=/etc/qbee/yocto/qbee-bootstrap-prep.sh
-ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
 TimeoutStopSec=3600


### PR DESCRIPTION
This pull request makes a small change to the `qbee-agent.service.in` systemd service file by removing the `ExecReload` directive. This means the service will no longer handle reload signals using `/bin/kill -HUP $MAINPID`.