### PR TITLE
DEV-2902: re-factor ci for kirkstone

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -3,20 +3,30 @@ permissions:
 name: meta-qbee-pr-tests
 on:
   pull_request:
-  push:
     branches:
       - master
+      - kirkstone
+      - scarthgap
+      - wrynose
 
+env:
+  # Environment variable for BitBake branch, defaulting to 'master' if not set
+  BITBAKE_MAP: >-
+    {
+      "kirkstone": "2.0",
+      "scarthgap": "2.8",
+      "wrynose": "2.18",
+      "master": "master"
+    }
 jobs:
   build:
     strategy:
       matrix:
-        arch: [x86_64,arm64]
-        branch: [kirkstone,scarthgap]
+        machine: [qemux86-64,qemuarm64]
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 600
     container:
-      image: ghcr.io/siemens/kas/kas:4.8.1 # Use the latest kas container image
+      image: ghcr.io/siemens/kas/kas:5.0-debian-bookworm # Use the latest kas container image
       options: --user 1000:1000
       env:
         KAS_CLONE_DEPTH: 0
@@ -34,9 +44,22 @@ jobs:
         with:
           clean: true
           fetch-depth: 0
+
       - name: Set up KAS
+        env:
+          KAS_MACHINE: ${{ matrix.machine }}
+          TARGET_BRANCH: ${{ github.base_ref }}
+          BITBAKE_BRANCH: ${{ fromJSON(env.BITBAKE_MAP)[github.base_ref] || 'master' }}
+          HEAD_BRANCH: ${{ github.head_ref }}
         run: |
-           kas checkout kas-poky-qbee-agent.${{ matrix.branch }}.${{ matrix.arch }}.yml
+          # Generate the KAS configuration file from the template, substituting environment variables
+          python3 -c 'import os,sys; print(os.path.expandvars(sys.stdin.read()))' \
+            < kas-qbee-agent.yml.template > kas-qbee-agent.yml
+
+          kas checkout kas-qbee-agent.yml
+
       - name: Build with KAS
+        env:
+          KAS_MACHINE: ${{ matrix.machine }}
         run: |
-          kas build kas-poky-qbee-agent.${{ matrix.branch }}.${{ matrix.arch }}.yml
+          kas build kas-qbee-agent.yml

--- a/kas-qbee-agent.yml.template
+++ b/kas-qbee-agent.yml.template
@@ -1,0 +1,53 @@
+header:
+  version: 8
+
+distro: poky
+target:
+  # build complete image
+  - core-image-minimal
+
+repos:
+  meta-qbee:
+    path: .
+    branch: ${HEAD_BRANCH}
+    layers:
+      meta-qbee:
+
+  bitbake:
+    url: https://git.openembedded.org/bitbake
+    path: layers/bitbake
+    branch: "${BITBAKE_BRANCH}"
+    layers:
+      .: disabled
+
+  openembedded-core:
+    url: https://git.openembedded.org/openembedded-core
+    path: layers/openembedded-core
+    branch: ${TARGET_BRANCH}
+    layers:
+      meta:
+
+  meta-yocto:
+    url: https://git.yoctoproject.org/meta-yocto
+    path: layers/meta-yocto
+    branch: ${TARGET_BRANCH}
+    layers:
+      meta-poky:
+      meta-yocto-bsp:
+
+local_conf_header:
+  standard: |
+    CONF_VERSION = "2"
+    QBEE_BOOTSTRAP_KEY = "${@os.getenv('QBEE_BOOTSTRAP_KEY', '')}"
+    # Downgrade buildpaths from an ERROR to a WARNING
+    ERROR_QA:remove = "buildpaths"
+    WARN_QA:append = " buildpaths"
+    BB_DISKMON_DIRS = "\
+        STOPTASKS,${TMPDIR},1G,100K \
+        STOPTASKS,${DL_DIR},1G,100K \
+        STOPTASKS,${SSTATE_DIR},1G,100K \
+        STOPTASKS,/tmp,100M,100K \
+        HALT,${TMPDIR},100M,1K \
+        HALT,${DL_DIR},100M,1K \
+        HALT,${SSTATE_DIR},100M,1K \
+        HALT,/tmp,10M,1K"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for pull request testing and introduces a new templated KAS configuration to improve maintainability and flexibility for different Yocto branches and machines. The changes streamline the CI process by using environment variables and templates, and update the build matrix and container image.

**CI/CD Workflow Improvements:**

* The workflow now supports additional branches (`kirkstone`, `scarthgap`, `wrynose`) and maps each to the correct BitBake branch using the new `BITBAKE_MAP` environment variable.
* The build matrix has been updated to use `machine` values (`qemux86-64`, `qemuarm64`) instead of separate architecture and branch combinations, simplifying configuration.
* The KAS container image is updated to `5.0-debian-bookworm` for a more recent build environment.

**KAS Configuration and Build Process:**

* The workflow now generates the KAS configuration (`kas-qbee-agent.yml`) from a new template file (`kas-qbee-agent.yml.template`), dynamically substituting environment variables for branches and machines, instead of using pre-generated files per arch/branch. [[1]](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eR47-R65) [[2]](diffhunk://#diff-f6ba142d402d0c4a5e2b906bc7cf1c08f3150c05139dc388cf18349bfe38835fR1-R53)
* The build and checkout steps are updated to use the generated `kas-qbee-agent.yml`, ensuring consistency and reducing duplication.

**New Files:**

* Added `kas-qbee-agent.yml.template`, which defines the structure and variables for generating the KAS configuration, supporting flexible builds for different branches and machines.