### PR TITLE
DEV-2932: Release qbee-agent 2026.19 - wrynose

### DIFF
--- a/meta-qbee/recipes-qbee/qbee-agent/qbee-agent_2026.19.bb
+++ b/meta-qbee/recipes-qbee/qbee-agent/qbee-agent_2026.19.bb
@@ -5,7 +5,7 @@ SRC_URI = "git://${GO_IMPORT};branch=main;protocol=https;destsuffix=${GO_SRCURI_
   file://qbee-agent.service.in \
   file://qbee-agent.init.in \
   "
-SRCREV = "ee332cd6910c27e4e8b0959adc32510c8cafa12b"
+SRCREV = "99a0b5a56bb0ae2d7dec29abcf25d29be16f2c36"
 
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM ?= "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"


### PR DESCRIPTION
This pull request updates the `qbee-agent` recipe to a new upstream version by changing the source revision and renaming the recipe file accordingly.

Version update:

* Updated the `SRCREV` in the `qbee-agent` recipe to point to commit `99a0b5a56bb0ae2d7dec29abcf25d29be16f2c36`, reflecting an upgrade from version 2026.11 to 2026.19 and renamed the recipe file from `qbee-agent_2026.11.bb` to `qbee-agent_2026.19.bb`.