### PR TITLE
DEV-2932: Release qbee-agent 2026.19 - scarthgap

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -62,4 +62,6 @@ jobs:
         env:
           KAS_MACHINE: ${{ matrix.machine }}
         run: |
+          # clean all sstate and downloads to ensure a clean build environment
+          kas cleansstate kas-qbee-agent.yml
           kas build kas-qbee-agent.yml

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -30,9 +30,9 @@ jobs:
       options: --user 1000:1000
       env:
         KAS_CLONE_DEPTH: 0
-        DL_DIR: /ci/yocto/downloads
-        SSTATE_DIR: /ci/yocto/sstate
-        TMPDIR: /ci/yocto/tmp
+        DL_DIR: /ci/yocto/ ${{ github.base_ref }}/downloads
+        SSTATE_DIR: /ci/yocto/${{ github.base_ref }}/sstate
+        TMPDIR: /ci/yocto/${{ github.base_ref }}/tmp
         # Environment variable for bootstrap key
         # This should be set in the GitHub repository secrets for security
         # when running integration tests with the platform
@@ -62,6 +62,4 @@ jobs:
         env:
           KAS_MACHINE: ${{ matrix.machine }}
         run: |
-          # clean all sstate and downloads to ensure a clean build environment
-          kas cleansstate kas-qbee-agent.yml
           kas build kas-qbee-agent.yml

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -30,7 +30,7 @@ jobs:
       options: --user 1000:1000
       env:
         KAS_CLONE_DEPTH: 0
-        DL_DIR: /ci/yocto/ ${{ github.base_ref }}/downloads
+        DL_DIR: /ci/yocto/downloads
         SSTATE_DIR: /ci/yocto/${{ github.base_ref }}/sstate
         TMPDIR: /ci/yocto/${{ github.base_ref }}/tmp
         # Environment variable for bootstrap key

--- a/meta-qbee/recipes-qbee/qbee-agent/qbee-agent_2026.19.bb
+++ b/meta-qbee/recipes-qbee/qbee-agent/qbee-agent_2026.19.bb
@@ -5,7 +5,7 @@ SRC_URI = "git://${GO_IMPORT};branch=main;protocol=https \
   file://qbee-agent.service.in \
   file://qbee-agent.init.in \
   "
-SRCREV = "ee332cd6910c27e4e8b0959adc32510c8cafa12b"
+SRCREV = "99a0b5a56bb0ae2d7dec29abcf25d29be16f2c36"
 
 LICENSE="Apache-2.0"
 LIC_FILES_CHKSUM ?= "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"


### PR DESCRIPTION
This pull request introduces two main changes: it updates the build environment configuration to use branch-specific directories for Yocto build artifacts, and it upgrades the `qbee-agent` recipe to a new version with an updated source revision.

Build environment improvements:

* Updated the `SSTATE_DIR` and `TMPDIR` environment variables in `.github/workflows/pr-test.yml` to use branch-specific directories based on `${{ github.base_ref }}`. This helps to isolate build artifacts by branch and avoid cross-branch contamination.

Yocto recipe update:

* Renamed the `qbee-agent` recipe from `qbee-agent_2026.11.bb` to `qbee-agent_2026.19.bb` and updated the `SRCREV` to `99a0b5a56bb0ae2d7dec29abcf25d29be16f2c36`, upgrading the agent to a newer version.This pull request updates the `qbee-agent` recipe to use a new source revision and renames the recipe file to reflect the new version. The main change is to track a newer commit of the `qbee-agent` source.

Version and source update:

* Renamed the recipe file from `qbee-agent_2026.11.bb` to `qbee-agent_2026.19.bb` and updated the `SRCREV` to `99a0b5a56bb0ae2d7dec29abcf25d29be16f2c36` to use the latest source code.