### PR TITLE
DEV-2902: scarthgap - add OEQA tests

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -31,8 +31,8 @@ jobs:
       env:
         KAS_CLONE_DEPTH: 0
         DL_DIR: /ci/yocto/downloads
-        SSTATE_DIR: /ci/yocto/sstate
-        TMPDIR: /ci/yocto/tmp
+        SSTATE_DIR: /ci/yocto/${{ github.base_ref }}/sstate
+        TMPDIR: /ci/yocto/${{ github.base_ref }}/tmp
         # Environment variable for bootstrap key
         # This should be set in the GitHub repository secrets for security
         # when running integration tests with the platform

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -31,8 +31,8 @@ jobs:
       env:
         KAS_CLONE_DEPTH: 0
         DL_DIR: /ci/yocto/downloads
-        SSTATE_DIR: /ci/yocto/${{ github.base_ref }}/sstate
-        TMPDIR: /ci/yocto/${{ github.base_ref }}/tmp
+        SSTATE_DIR: /ci/yocto/sstate
+        TMPDIR: /ci/yocto/tmp
         # Environment variable for bootstrap key
         # This should be set in the GitHub repository secrets for security
         # when running integration tests with the platform

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -8,7 +8,6 @@ on:
       - kirkstone
       - scarthgap
       - wrynose
-
 env:
   # Environment variable for BitBake branch, defaulting to 'master' if not set
   BITBAKE_MAP: >-
@@ -18,6 +17,7 @@ env:
       "wrynose": "2.18",
       "master": "master"
     }
+
 jobs:
   build:
     strategy:
@@ -26,7 +26,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 600
     container:
-      image: ghcr.io/siemens/kas/kas:5.0-debian-bookworm # Use the latest kas container image
+      image: ghcr.io/siemens/kas/kas:5.0-debian-bookworm
       options: --user 1000:1000
       env:
         KAS_CLONE_DEPTH: 0
@@ -39,6 +39,8 @@ jobs:
         QBEE_BOOTSTRAP_KEY: my-bootstrap-key
       volumes:
         - /home/runner/ci/yocto:/ci/yocto
+        - /etc/passwd:/etc/passwd:ro
+        - /etc/group:/etc/group:ro
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,3 +65,9 @@ jobs:
           KAS_MACHINE: ${{ matrix.machine }}
         run: |
           kas build kas-qbee-agent.yml
+
+      - name: Run OEQA tests with KAS
+        env:
+          KAS_MACHINE: ${{ matrix.machine }}
+        run: |
+          kas build kas-qbee-agent-test.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 meta-qbee/build/tmp/
+layers

--- a/kas-qbee-agent-test.yml
+++ b/kas-qbee-agent-test.yml
@@ -1,0 +1,23 @@
+header:
+  version: 8
+  includes:
+    - kas-qbee-agent.yml
+
+target:
+  - core-image-minimal
+
+task: testimage
+
+local_conf_header:
+  testing: |
+    IMAGE_INSTALL:append = " qbee-agent dropbear"    
+    IMAGE_CLASSES += "testimage"
+    TEST_SUITES = "ping ssh qbee"
+    EXTRA_IMAGE_FEATURES += "ssh-server-dropbear allow-empty-password empty-root-password allow-root-login"
+    # Legacy Kirkstone qemu toggles
+    QEMU_USE_SLIRP = "1"
+    QEMU_USE_KVM = "0"
+    # modern LTS qemu toggles
+    TEST_RUNQEMUPARAMS += " slirp"
+    TEST_SERIALCONTROL_STATUS = "0"
+    TESTIMAGE_AUTO = "1"

--- a/kas-qbee-agent.yml.template
+++ b/kas-qbee-agent.yml.template
@@ -38,6 +38,8 @@ repos:
 local_conf_header:
   standard: |
     CONF_VERSION = "2"
+    BB_HASHSERVE_DB_DIR = "${SSTATE_DIR}"
+    INIT_MANAGER = "systemd"
     QBEE_BOOTSTRAP_KEY = "${@os.getenv('QBEE_BOOTSTRAP_KEY', '')}"
     # Downgrade buildpaths from an ERROR to a WARNING
     ERROR_QA:remove = "buildpaths"

--- a/meta-qbee/lib/oeqa/runtime/cases/qbee.py
+++ b/meta-qbee/lib/oeqa/runtime/cases/qbee.py
@@ -4,7 +4,6 @@ import tempfile
 from oeqa.runtime.case import OERuntimeTestCase
 from oeqa.core.decorator.depends import OETestDepends
 from oeqa.runtime.decorator.package import OEHasPackage
-from oeqa.utils.commands import runCmd
 
 class QbeeAgentTest(OERuntimeTestCase):
   @OEHasPackage(['qbee-agent'])
@@ -34,63 +33,82 @@ class QbeeAgentTest(OERuntimeTestCase):
     """ Create a bootstrap env file with all available options to verify that the script can handle them without error. """
     bootstrapEnvFile = tempfile.NamedTemporaryFile(delete=False)
     qbeeAgentJsonFile = tempfile.NamedTemporaryFile(delete=False)
+    qbeeAgentJsonFile.close()
     bootstrapEnvTargetPath = "/etc/qbee/yocto/.bootstrap-env"
     qbeeAgentConfigFile = "/data/qbee/etc/qbee-agent.json"
 
-    lines = [
-      "BOOTSTRAP_KEY=my-key",
-      "DEVICE_NAME_TYPE=machine-id",
-      "DEVICE_HUB_HOST=device.app.qbee.io",
-      "DISABLE_REMOTE_ACCESS=true",
-      "TPM_DEVICE=/dev/tpm0",
-      "CA_CERT=/etc/qbee/ca_cert.pem",
-      "ELEVATION_COMMAND='[\"/usr/bin/sudo\", \"-n\"]'",
+    test_cases = [
+      ("BOOTSTRAP_KEY=my-key", "bootstrap_key", "my-key"),
+      ("DEVICE_NAME_TYPE=machine-id", "device_name", ""),
+      ("DEVICE_HUB_HOST=device.app.qbee.io", "server", "device.app.qbee.io"),
+      ("DISABLE_REMOTE_ACCESS=true", "disable_remote_access", True),
+      # use a valid character device name to ensure that the value is properly passed through and not rejected by qbee-bootstrap-prep.sh
+      ("TPM_DEVICE=/dev/null", "tpm_device", "/dev/null"),
+      ("CA_CERT=/etc/qbee/yocto/ca.cert", "ca_cert", "/etc/qbee/yocto/ca.cert"),
+      ("ELEVATION_COMMAND='[\"/usr/bin/sudo\", \"-n\"]'", "elevation_command", ["/usr/bin/sudo", "-n"]),
     ]
 
-    for line in lines:
+    for line, expected_key, expected_value in test_cases:
       bootstrapEnvFile.write(f"{line}\n".encode('utf-8'))
       bootstrapEnvFile.flush()
 
       status, output = self.target.copyTo(bootstrapEnvFile.name, bootstrapEnvTargetPath)
       self.assertEqual(status, 0, msg=f"Failed to copy bootstrap env file: {output}")
       
-      status, output = self.target.run(f'sync')
+      status, output = self.target.run('sync')
       self.assertEqual(status, 0, msg=f"Failed to sync files: {output}")
 
-      status, output = self.target.run(f'/etc/qbee/yocto/qbee-bootstrap-prep.sh 2>&1')
+      status, output = self.target.run('/etc/qbee/yocto/qbee-bootstrap-prep.sh 2>&1')
       self.assertEqual(status, 0, msg=f"qbee-bootstrap-prep.sh failed to execute with env {line}: {output}")
 
       status, output = self.target.copyFrom(qbeeAgentConfigFile, qbeeAgentJsonFile.name)
       self.assertEqual(status, 0, msg=f"Failed to copy qbee-agent.json file: {output}")
 
-      """ Verify that the json file is parseable and contains the expected key based on the env variable set. """
-      data = json.loads(open(qbeeAgentJsonFile.name, 'r').read())
-      self.assertIsNotNone(data, msg=f"Failed to parse qbee-agent.json file with env {line}")
+      # Verify that the JSON file is parseable.
+      with open(qbeeAgentJsonFile.name, 'r') as qbeeAgentJson:
+        data = json.load(qbeeAgentJson)
+        self.assertIsNotNone(data, msg=f"Failed to parse qbee-agent.json file with env {line}")
+        if expected_key:
+          self.assertIn(expected_key, data, msg=f"Expected key '{expected_key}' missing from qbee-agent.json for env {line}")
+          if expected_value:
+            self.assertEqual(data[expected_key], expected_value, msg=f"Unexpected value for key '{expected_key}' in qbee-agent.json for env {line}")
 
       self.target.run(f'rm -f {bootstrapEnvTargetPath} && rm -f {qbeeAgentConfigFile}')
 
   @OETestDepends(['qbee.QbeeAgentTest.test_qbee_agent_bootstrap_pre_script'])
   def test_qbee_agent_systemd_integration(self):
-    """ create a replacement script that runs in a loop and verify that systemd restarts it as expected. """
-    testScript = tempfile.NamedTemporaryFile(delete=False)
-    testScript.write(b"#!/bin/sh\nwhile true; do echo 'test'; sleep 1; done")
-    testScript.flush()
-    self.target.copyTo(testScript.name, "/usr/bin/qbee-agent")
-    self.target.run("chmod +x /usr/bin/qbee-agent")
+    """Temporarily replace qbee-agent and verify the systemd unit can start/stop it."""
+    backup_path = "/usr/bin/qbee-agent.oeqa.bak"
+    status, output = self.target.run(f"cp /usr/bin/qbee-agent {backup_path}")
+    self.assertEqual(status, 0, msg=f"Failed to backup qbee-agent binary: {output}")
 
-    """ Create an env file make sure that qbee-agent.json gets generated """
-    bootstrapEnvFile = tempfile.NamedTemporaryFile(delete=False)
-    bootstrapEnvFile.write(b"BOOTSTRAP_KEY=my-key")
-    bootstrapEnvFile.flush()
-    self.target.copyTo(bootstrapEnvFile.name, "/etc/qbee/yocto/.bootstrap-env")
-    self.target.run('sync')
+    try:
+      testScript = tempfile.NamedTemporaryFile(delete=False)
+      testScript.write(b"#!/bin/sh\nwhile true; do echo 'test'; sleep 1; done\n")
+      testScript.flush()
 
-    """ Start the service and verify that it is running """
-    self.target.run('systemctl start qbee-agent.service')
-    status, output = self.target.run('systemctl is-active qbee-agent.service')
-    self.assertEqual(status, 0, msg=f"qbee-agent service failed to start: {output}")
+      status, output = self.target.copyTo(testScript.name, "/usr/bin/qbee-agent")
+      self.assertEqual(status, 0, msg=f"Failed to install test qbee-agent binary: {output}")
+      status, output = self.target.run("chmod +x /usr/bin/qbee-agent")
+      self.assertEqual(status, 0, msg=f"Failed to chmod test qbee-agent binary: {output}")
 
-    """ Stop the service and verify that it is stopped """
-    self.target.run('systemctl stop qbee-agent.service')
-    status, output = self.target.run('systemctl is-active qbee-agent.service')
-    self.assertNotEqual(status, 0, msg=f"qbee-agent service failed to stop: {output}")
+      # Create an env file so qbee-agent.json gets generated
+      bootstrapEnvFile = tempfile.NamedTemporaryFile(delete=False)
+      bootstrapEnvFile.write(b"BOOTSTRAP_KEY=my-key\n")
+      bootstrapEnvFile.flush()
+      status, output = self.target.copyTo(bootstrapEnvFile.name, "/etc/qbee/yocto/.bootstrap-env")
+      self.assertEqual(status, 0, msg=f"Failed to copy bootstrap env file: {output}")
+      self.target.run('sync')
+
+      # Start the service and verify that it is running
+      self.target.run('systemctl start qbee-agent.service')
+      status, output = self.target.run('systemctl is-active qbee-agent.service')
+      self.assertEqual(status, 0, msg=f"qbee-agent service failed to start: {output}")
+
+      # Stop the service and verify that it is stopped
+      self.target.run('systemctl stop qbee-agent.service')
+      status, output = self.target.run('systemctl is-active qbee-agent.service')
+      self.assertNotEqual(status, 0, msg=f"qbee-agent service failed to stop: {output}")
+    finally:
+      self.target.run(f"mv -f {backup_path} /usr/bin/qbee-agent")
+      self.target.run("chmod +x /usr/bin/qbee-agent")

--- a/meta-qbee/lib/oeqa/runtime/cases/qbee.py
+++ b/meta-qbee/lib/oeqa/runtime/cases/qbee.py
@@ -1,0 +1,96 @@
+import json
+import tempfile
+
+from oeqa.runtime.case import OERuntimeTestCase
+from oeqa.core.decorator.depends import OETestDepends
+from oeqa.runtime.decorator.package import OEHasPackage
+from oeqa.utils.commands import runCmd
+
+class QbeeAgentTest(OERuntimeTestCase):
+  @OEHasPackage(['qbee-agent'])
+  @OETestDepends(['ssh.SSHTest.test_ssh'])
+  def test_qbee_binary_execution(self):
+    """Verify the qbee-agent binary exists, has correct permissions, and executes."""
+    status, _ = self.target.run('test -x /usr/bin/qbee-agent')
+    self.assertEqual(status, 0, msg="qbee-agent binary is missing or not executable.")
+
+    status, output = self.target.run('qbee-agent --help')
+    self.assertEqual(status, 0, msg=f"qbee-agent failed to execute: {output}")
+
+  @OETestDepends(['qbee.QbeeAgentTest.test_qbee_binary_execution'])
+  def test_qbee_config_directory(self):
+    """Verify that the configuration directory was created."""
+    status, _ = self.target.run('test -d /etc/qbee')
+    self.assertEqual(status, 0, msg="/etc/qbee directory does not exist.")
+
+  @OETestDepends(['qbee.QbeeAgentTest.test_qbee_binary_execution'])
+  def test_qbee_service_enabled(self):
+    """Verify that the systemd service is enabled to start on boot."""
+    status, output = self.target.run('systemctl is-enabled qbee-agent.service')
+    self.assertEqual(status, 0, msg=f"qbee-agent service is not enabled: {output}")
+
+  @OETestDepends(['qbee.QbeeAgentTest.test_qbee_binary_execution'])
+  def test_qbee_agent_bootstrap_pre_script(self):
+    """ Create a bootstrap env file with all available options to verify that the script can handle them without error. """
+    bootstrapEnvFile = tempfile.NamedTemporaryFile(delete=False)
+    qbeeAgentJsonFile = tempfile.NamedTemporaryFile(delete=False)
+    bootstrapEnvTargetPath = "/etc/qbee/yocto/.bootstrap-env"
+    qbeeAgentConfigFile = "/data/qbee/etc/qbee-agent.json"
+
+    lines = [
+      "BOOTSTRAP_KEY=my-key",
+      "DEVICE_NAME_TYPE=machine-id",
+      "DEVICE_HUB_HOST=device.app.qbee.io",
+      "DISABLE_REMOTE_ACCESS=true",
+      "TPM_DEVICE=/dev/tpm0",
+      "CA_CERT=/etc/qbee/ca_cert.pem",
+      "ELEVATION_COMMAND='[\"/usr/bin/sudo\", \"-n\"]'",
+    ]
+
+    for line in lines:
+      bootstrapEnvFile.write(f"{line}\n".encode('utf-8'))
+      bootstrapEnvFile.flush()
+
+      status, output = self.target.copyTo(bootstrapEnvFile.name, bootstrapEnvTargetPath)
+      self.assertEqual(status, 0, msg=f"Failed to copy bootstrap env file: {output}")
+      
+      status, output = self.target.run(f'sync')
+      self.assertEqual(status, 0, msg=f"Failed to sync files: {output}")
+
+      status, output = self.target.run(f'/etc/qbee/yocto/qbee-bootstrap-prep.sh 2>&1')
+      self.assertEqual(status, 0, msg=f"qbee-bootstrap-prep.sh failed to execute with env {line}: {output}")
+
+      status, output = self.target.copyFrom(qbeeAgentConfigFile, qbeeAgentJsonFile.name)
+      self.assertEqual(status, 0, msg=f"Failed to copy qbee-agent.json file: {output}")
+
+      """ Verify that the json file is parseable and contains the expected key based on the env variable set. """
+      data = json.loads(open(qbeeAgentJsonFile.name, 'r').read())
+      self.assertIsNotNone(data, msg=f"Failed to parse qbee-agent.json file with env {line}")
+
+      self.target.run(f'rm -f {bootstrapEnvTargetPath} && rm -f {qbeeAgentConfigFile}')
+
+  @OETestDepends(['qbee.QbeeAgentTest.test_qbee_agent_bootstrap_pre_script'])
+  def test_qbee_agent_systemd_integration(self):
+    """ create a replacement script that runs in a loop and verify that systemd restarts it as expected. """
+    testScript = tempfile.NamedTemporaryFile(delete=False)
+    testScript.write(b"#!/bin/sh\nwhile true; do echo 'test'; sleep 1; done")
+    testScript.flush()
+    self.target.copyTo(testScript.name, "/usr/bin/qbee-agent")
+    self.target.run("chmod +x /usr/bin/qbee-agent")
+
+    """ Create an env file make sure that qbee-agent.json gets generated """
+    bootstrapEnvFile = tempfile.NamedTemporaryFile(delete=False)
+    bootstrapEnvFile.write(b"BOOTSTRAP_KEY=my-key")
+    bootstrapEnvFile.flush()
+    self.target.copyTo(bootstrapEnvFile.name, "/etc/qbee/yocto/.bootstrap-env")
+    self.target.run('sync')
+
+    """ Start the service and verify that it is running """
+    self.target.run('systemctl start qbee-agent.service')
+    status, output = self.target.run('systemctl is-active qbee-agent.service')
+    self.assertEqual(status, 0, msg=f"qbee-agent service failed to start: {output}")
+
+    """ Stop the service and verify that it is stopped """
+    self.target.run('systemctl stop qbee-agent.service')
+    status, output = self.target.run('systemctl is-active qbee-agent.service')
+    self.assertNotEqual(status, 0, msg=f"qbee-agent service failed to stop: {output}")


### PR DESCRIPTION
This pull request introduces automated runtime testing for the `qbee-agent` integration in the Yocto build process and updates the CI workflow accordingly. The changes include the addition of a new kas configuration for running OEQA tests, enhancements to the test workflow, and the implementation of a comprehensive test suite for the `qbee-agent` using OEQA.

**CI/CD Workflow Enhancements:**

* Updated `.github/workflows/pr-test.yml` to mount `/etc/passwd` and `/etc/group` as read-only in the build container, improving user and group handling during builds.
* Added a new CI step to run OEQA tests with KAS using the new `kas-qbee-agent-test.yml` configuration, ensuring runtime validation of the `qbee-agent`.

**Testing Infrastructure:**

* Introduced `kas-qbee-agent-test.yml`, which extends the standard build to include test support (OEQA), additional image features, and configuration for running test suites such as `ping`, `ssh`, and `qbee`.
* Enhanced `kas-qbee-agent.yml.template` to set `BB_HASHSERVE_DB_DIR` and `INIT_MANAGER`, improving build reproducibility and ensuring systemd is used as the init system.

**Automated Runtime Test Suite:**

* Added `meta-qbee/lib/oeqa/runtime/cases/qbee.py`, implementing a robust OEQA runtime test class for `qbee-agent`. This includes tests for binary presence and execution, configuration directory creation, systemd service enablement, bootstrap script handling, and systemd integration/restart behavior.