### PR TITLE
DEV-3044: Release qbee-agent 2026.27 - scarthgap

### DIFF
--- a/meta-qbee/recipes-qbee/qbee-agent/qbee-agent_2026.27.bb
+++ b/meta-qbee/recipes-qbee/qbee-agent/qbee-agent_2026.27.bb
@@ -5,7 +5,7 @@ SRC_URI = "git://${GO_IMPORT};branch=main;protocol=https \
   file://qbee-agent.service.in \
   file://qbee-agent.init.in \
   "
-SRCREV = "99a0b5a56bb0ae2d7dec29abcf25d29be16f2c36"
+SRCREV = "6710abd49906d00ba6c4e446f6436faab14fb5d9"
 
 LICENSE="Apache-2.0"
 LIC_FILES_CHKSUM ?= "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"


### PR DESCRIPTION
This pull request updates the `qbee-agent` recipe to use a new source revision and renames the recipe file to reflect the updated version.

Version and source update:

* Renamed the recipe file from `qbee-agent_2026.19.bb` to `qbee-agent_2026.27.bb` to indicate the new version.
* Updated the `SRCREV` variable to point to the latest commit hash, ensuring the build uses the most recent code from the `main` branch.